### PR TITLE
Add MetaRadar-inspired BLE scanning support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,15 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="false" />
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotDropDownReceiver.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotDropDownReceiver.java
@@ -42,13 +42,14 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
 
     private final wifi2cotMapComponent mc;
 
-    private final Button start, stop, guess;
+    private final Button start, stop, guess, startBle, stopBle, guessBle;
 
     private Timer timer;
 
     private static final int MIN_SAMPLE_SIZE_FOR_DISPATCH = 3;
 
     private boolean scanning = false;
+    private boolean bleScanning = false;
 
     /**************************** CONSTRUCTOR *****************************/
 
@@ -67,6 +68,9 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
         start = templateView.findViewById(R.id.start);
         stop = templateView.findViewById(R.id.stop);
         guess = templateView.findViewById(R.id.guess);
+        startBle = templateView.findViewById(R.id.start_ble);
+        stopBle = templateView.findViewById(R.id.stop_ble);
+        guessBle = templateView.findViewById(R.id.guess_ble);
     }
 
     /**************************** PUBLIC METHODS *****************************/
@@ -77,6 +81,8 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
             timer = null;
             scanning = false;
         }
+        mc.stopBleScan();
+        bleScanning = false;
     }
 
     /**************************** INHERITED METHODS *****************************/
@@ -127,6 +133,34 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
                         Toast.LENGTH_LONG).show();
                 compute();
             });
+
+            startBle.setOnClickListener(view -> {
+                Log.d(TAG, "Starting BLE scan");
+                wifi2cotMapComponent.getBleNodes().clear();
+                if (mc.startBleScan()) {
+                    bleScanning = true;
+                    Toast.makeText(MapView._mapView.getContext(), "Starting BLE scan",
+                            Toast.LENGTH_LONG).show();
+                } else {
+                    bleScanning = false;
+                    Toast.makeText(MapView._mapView.getContext(),
+                            "Unable to start BLE scan", Toast.LENGTH_LONG).show();
+                }
+            });
+
+            stopBle.setOnClickListener(view -> {
+                Log.d(TAG, "Stopping BLE scan");
+                mc.stopBleScan();
+                bleScanning = false;
+                Toast.makeText(MapView._mapView.getContext(), "Stopping BLE scan",
+                        Toast.LENGTH_LONG).show();
+            });
+
+            guessBle.setOnClickListener(view -> {
+                Toast.makeText(MapView._mapView.getContext(),
+                        "Dispatching BLE results", Toast.LENGTH_LONG).show();
+                computeBle();
+            });
         }
     }
 
@@ -149,6 +183,8 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
             timer = null;
             scanning = false;
         }
+        mc.stopBleScan();
+        bleScanning = false;
     }
 
     public void compute() {
@@ -156,8 +192,28 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
         Log.d(TAG, "In compute");
 
         HashMap<String, List<String[]>> nodes = wifi2cotMapComponent.getNodes();
-
         List<AccessPointSummary> summaries = buildAccessPointSummaries(nodes);
+        dispatchSummaries(summaries, "a-f-G-I-E", "wifi2cot");
+    }
+
+    public boolean isScanning() {
+        return scanning;
+    }
+
+    public boolean isBleScanning() {
+        return bleScanning;
+    }
+
+    private void computeBle() {
+        Log.d(TAG, "In computeBle");
+
+        HashMap<String, List<String[]>> nodes = wifi2cotMapComponent.getBleNodes();
+        List<AccessPointSummary> summaries = buildAccessPointSummaries(nodes);
+        dispatchSummaries(summaries, "b-l-l", "MetaRadar");
+    }
+
+    private void dispatchSummaries(List<AccessPointSummary> summaries,
+            String cotType, String sourceLabel) {
         for (AccessPointSummary summary : summaries) {
             if (summary.sampleSize < MIN_SAMPLE_SIZE_FOR_DISPATCH) {
                 Log.d(TAG, String.format(Locale.US,
@@ -165,6 +221,9 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
                         summary.sampleSize));
                 continue;
             }
+
+            String displayName = (summary.ssid == null || summary.ssid.isEmpty())
+                    ? summary.bssid : summary.ssid;
 
             Log.d(TAG, String.format(Locale.US,
                     "Dispatching %s at %.14f, %.14f (avg strength %.2f)",
@@ -180,7 +239,7 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
 
             cotEvent.setUID(summary.bssid);
 
-            cotEvent.setType("a-f-G-I-E");
+            cotEvent.setType(cotType);
 
             cotEvent.setHow("m-g");
 
@@ -192,14 +251,14 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
             cotEvent.setDetail(cotDetail);
 
             CotDetail contactDetail = new CotDetail("contact");
-            contactDetail.setAttribute("callsign", summary.ssid);
+            contactDetail.setAttribute("callsign", displayName);
             contactDetail.setAttribute("endpoint", "0.0.0.0:4242:tcp");
 
             CotDetail cotRemark = new CotDetail("remarks");
-            cotRemark.setAttribute("source", "wifi2cot");
+            cotRemark.setAttribute("source", sourceLabel);
             cotRemark.setInnerText(String.format(Locale.US,
-                    "SSID: %s\nSample size: %d\nAverage signal quality: %.2f\nBest sample: %d\nWorst sample: %d",
-                    summary.ssid, summary.sampleSize, summary.averageSignal,
+                    "Label: %s\nSample size: %d\nAverage signal quality: %.2f\nBest sample: %d\nWorst sample: %d",
+                    displayName, summary.sampleSize, summary.averageSignal,
                     summary.strongestSample, summary.weakestSample));
 
             cotDetail.addChild(contactDetail);
@@ -210,10 +269,6 @@ public class wifi2cotDropDownReceiver extends DropDownReceiver implements
             else
                 Log.e(TAG, "cotEvent was not valid");
         }
-    }
-
-    public boolean isScanning() {
-        return scanning;
     }
 
     private List<AccessPointSummary> buildAccessPointSummaries(

--- a/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotMapComponent.java
+++ b/app/src/main/java/com/atakmap/android/wifi2cot/wifi2cotMapComponent.java
@@ -1,12 +1,18 @@
 
 package com.atakmap.android.wifi2cot;
 
+import android.annotation.SuppressLint;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanResult;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.net.wifi.ScanResult;
 import android.net.wifi.WifiManager;
+import android.os.Build;
 
 import com.atakmap.android.ipc.AtakBroadcast.DocumentedIntentFilter;
 
@@ -35,8 +41,16 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
 
     private BroadcastReceiver wifiScanReceiver;
 
+    private BluetoothAdapter bluetoothAdapter;
+
+    private BluetoothLeScanner bluetoothLeScanner;
+
+    private ScanCallback bleScanCallback;
+
     // nodes will hold k,v for the BSSID and the rssi,lat,lng,bssid,ssid values
     private final static HashMap<String, List<String[]>> nodes = new HashMap<>();
+
+    private final static HashMap<String, List<String[]>> bleNodes = new HashMap<>();
 
     public void onCreate(final Context context, Intent intent,
             final MapView view) {
@@ -55,6 +69,19 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
         registerDropDownReceiver(ddr, ddFilter);
 
         wifiManager = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            BluetoothManager bluetoothManager =
+                    (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);
+            if (bluetoothManager != null) {
+                bluetoothAdapter = bluetoothManager.getAdapter();
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                        && bluetoothAdapter != null) {
+                    bluetoothLeScanner = bluetoothAdapter.getBluetoothLeScanner();
+                    bleScanCallback = createBleScanCallback();
+                }
+            }
+        }
 
         wifiScanReceiver = new BroadcastReceiver() {
             @Override
@@ -109,8 +136,8 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
             @Override
             public void run() {
 
-                List<ScanResult> results = wifiManager.getScanResults();
-                for (ScanResult s: results) {
+                List<android.net.wifi.ScanResult> results = wifiManager.getScanResults();
+                for (android.net.wifi.ScanResult s : results) {
 
                     Log.d(TAG, "Scan result: BSSID: " + s.BSSID + " SSID: " + s.SSID + " RSSI: " + s.level + " Freq: " + s.frequency);
 
@@ -166,9 +193,157 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
     private void scanFailure() {
         // handle failure: new scan did NOT succeed
         // consider using old scan results: these are the OLD results!
-        List<ScanResult> results = wifiManager.getScanResults();
+        List<android.net.wifi.ScanResult> results = wifiManager.getScanResults();
         Log.d(TAG, "Scan failed");
 //  ... potentially use older scan results ...
+    }
+
+    private ScanCallback createBleScanCallback() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return null;
+        }
+
+        return new ScanCallback() {
+            @Override
+            public void onScanResult(int callbackType, ScanResult result) {
+                handleBleScanResult(result);
+            }
+
+            @Override
+            public void onBatchScanResults(List<ScanResult> results) {
+                if (results == null) {
+                    return;
+                }
+                for (ScanResult result : results) {
+                    handleBleScanResult(result);
+                }
+            }
+
+            @Override
+            public void onScanFailed(int errorCode) {
+                Log.e(TAG, "BLE scan failed: " + errorCode);
+            }
+        };
+    }
+
+    private void handleBleScanResult(ScanResult result) {
+        if (result == null || ddr == null || !ddr.isBleScanning()) {
+            return;
+        }
+
+        if (mapView == null || mapView.getSelfMarker() == null
+                || mapView.getSelfMarker().getPoint() == null) {
+            Log.d(TAG, "MapView not ready for BLE sample");
+            return;
+        }
+
+        double lat = mapView.getSelfMarker().getPoint().getLatitude();
+        double lng = mapView.getSelfMarker().getPoint().getLongitude();
+
+        if (lat == 0.0 && lng == 0.0) {
+            Log.d(TAG, "No GPS fix for BLE sample");
+            return;
+        }
+
+        String latString = String.valueOf(lat);
+        String lngString = String.valueOf(lng);
+
+        if (latString.startsWith("0.0") && lngString.startsWith("0.0")) {
+            return;
+        }
+
+        if (result.getDevice() == null || result.getDevice().getAddress() == null
+                || result.getDevice().getAddress().isEmpty()) {
+            return;
+        }
+
+        String address = result.getDevice().getAddress();
+        String name = result.getDevice().getName();
+        if (name == null) {
+            name = "";
+        }
+
+        int quality = 100 - Math.abs(result.getRssi());
+        if (quality < 0) {
+            quality = 0;
+        }
+
+        String[] sample = new String[5];
+        sample[0] = String.valueOf(quality);
+        sample[1] = latString;
+        sample[2] = lngString;
+        sample[3] = address;
+        sample[4] = name;
+
+        synchronized (bleNodes) {
+            List<String[]> data = bleNodes.get(address);
+            if (data == null) {
+                data = new ArrayList<>();
+                bleNodes.put(address, data);
+            }
+            data.add(sample);
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    public boolean startBleScan() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            Log.w(TAG, "BLE scanning not supported on this device");
+            return false;
+        }
+
+        if (bluetoothAdapter == null) {
+            Log.w(TAG, "Bluetooth adapter not available");
+            return false;
+        }
+
+        if (!bluetoothAdapter.isEnabled()) {
+            Log.w(TAG, "Bluetooth adapter is disabled");
+            return false;
+        }
+
+        if (bluetoothLeScanner == null) {
+            bluetoothLeScanner = bluetoothAdapter.getBluetoothLeScanner();
+        }
+
+        if (bluetoothLeScanner == null) {
+            Log.w(TAG, "Bluetooth LE scanner not available");
+            return false;
+        }
+
+        if (bleScanCallback == null) {
+            bleScanCallback = createBleScanCallback();
+        }
+
+        if (bleScanCallback == null) {
+            Log.w(TAG, "BLE scan callback not initialized");
+            return false;
+        }
+
+        try {
+            bluetoothLeScanner.startScan(bleScanCallback);
+            return true;
+        } catch (SecurityException e) {
+            Log.e(TAG, "Missing permission to start BLE scan", e);
+            return false;
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    public void stopBleScan() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
+
+        if (bluetoothLeScanner == null || bleScanCallback == null) {
+            return;
+        }
+
+        try {
+            bluetoothLeScanner.stopScan(bleScanCallback);
+        } catch (SecurityException e) {
+            Log.e(TAG, "Missing permission to stop BLE scan", e);
+        }
     }
 
     @Override
@@ -176,6 +351,7 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
         if (wifiScanReceiver != null) {
             context.unregisterReceiver(wifiScanReceiver);
         }
+        stopBleScan();
         super.onDestroyImpl(context, view);
     }
 
@@ -185,6 +361,10 @@ public class wifi2cotMapComponent extends DropDownMapComponent {
 
     public static HashMap<String, List<String[]>> getNodes() {
         return nodes;
+    }
+
+    public static HashMap<String, List<String[]>> getBleNodes() {
+        return bleNodes;
     }
 
 }

--- a/app/src/main/res/layout/main_layout.xml
+++ b/app/src/main/res/layout/main_layout.xml
@@ -41,5 +41,32 @@
             android:text="Take a Guess"
             android:id="@+id/guess"/>
 
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="16dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="MetaRadar BLE Scanning" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Start BLE Scan"
+            android:id="@+id/start_ble"/>
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Stop BLE Scan"
+            android:id="@+id/stop_ble"/>
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Dispatch BLE Results"
+            android:id="@+id/guess_ble"/>
+
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
## Summary
- add Bluetooth permissions and BLE hardware declaration to enable MetaRadar-style scanning
- extend the drop-down UI with controls for starting, stopping, and dispatching BLE scan results
- add BLE scanning pipeline that captures device samples and dispatches CoT events with MetaRadar metadata

## Testing
- not run (requires proprietary signing configuration)


------
https://chatgpt.com/codex/tasks/task_b_68d6a05714b0832ebb6bbcb50a61d0c4