### PR TITLE
Add string resources for scanning UI labels

### DIFF
--- a/app/src/main/res/layout/main_layout.xml
+++ b/app/src/main/res/layout/main_layout.xml
@@ -20,25 +20,25 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Wi-Fi Scanning" />
+            android:text="@string/wifi_scanning_title" />
 
         <Button
             android:id="@+id/start"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Start Scan" />
+            android:text="@string/start_scan" />
 
         <Button
             android:id="@+id/stop"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Stop Scan" />
+            android:text="@string/stop_scan" />
 
         <Button
             android:id="@+id/guess"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Take a Guess" />
+            android:text="@string/take_guess" />
 
         <TextView
             android:id="@+id/tracking_status"
@@ -78,24 +78,24 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="MetaRadar BLE Scanning" />
+            android:text="@string/ble_scanning_title" />
 
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Start BLE Scan"
+            android:text="@string/start_ble_scan"
             android:id="@+id/start_ble"/>
 
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Stop BLE Scan"
+            android:text="@string/stop_ble_scan"
             android:id="@+id/stop_ble"/>
 
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Dispatch BLE Results"
+            android:text="@string/dispatch_ble_results"
             android:id="@+id/guess_ble"/>
 
         <View
@@ -105,24 +105,24 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="MetaRadar BLE Scanning" />
+            android:text="@string/ble_scanning_title" />
 
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Start BLE Scan"
+            android:text="@string/start_ble_scan"
             android:id="@+id/start_ble"/>
 
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Stop BLE Scan"
+            android:text="@string/stop_ble_scan"
             android:id="@+id/stop_ble"/>
 
         <Button
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Dispatch BLE Results"
+            android:text="@string/dispatch_ble_results"
             android:id="@+id/guess_ble"/>
 
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,12 @@
     <string name="type_ble">BLE</string>
     <string name="available_signals">Available Signals</string>
     <string name="no_signals_available">No signal sources discovered yet.</string>
+    <string name="wifi_scanning_title">Wi-Fi Scanning</string>
+    <string name="start_scan">Start Scan</string>
+    <string name="stop_scan">Stop Scan</string>
+    <string name="take_guess">Take a Guess</string>
+    <string name="ble_scanning_title">MetaRadar BLE Scanning</string>
+    <string name="start_ble_scan">Start BLE Scan</string>
+    <string name="stop_ble_scan">Stop BLE Scan</string>
+    <string name="dispatch_ble_results">Dispatch BLE Results</string>
 </resources>


### PR DESCRIPTION
## Summary
- add string resources for the Wi-Fi and BLE scanning controls so they are centrally defined
- update the main layout to use the new string resources instead of hard-coded text

## Testing
- ./gradlew assembleDebug *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_b_68d6be4e74b8832ebc5492e86ee4b74e